### PR TITLE
Add tests to reproduce tracks color_by failures when changing properties

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
@@ -40,7 +40,8 @@ def test_tracks_controls_color_by(qtbot):
     assert qtctrl.color_by_combobox.currentText() == qt_update_color_by
 
 
-def test_color_by_same_after_properties_change(qtbot):
+@pytest.mark.parametrize('color_by', ('track_id', 'confidence'))
+def test_color_by_same_after_properties_change(color_by, qtbot):
     """See https://github.com/napari/napari/issues/5330"""
     data = np.array(
         [
@@ -55,20 +56,20 @@ def test_color_by_same_after_properties_change(qtbot):
             [3, 2, 636, 200],
         ]
     )
-    np.random.seed(0)
     initial_properties = {
+        'track_id': data[:, 0],
         'time': data[:, 1],
-        'confidence': np.random.rand(data.shape[0]),
+        'confidence': np.ones(data.shape[0]),
     }
-    layer = Tracks(
-        data,
-        properties=initial_properties,
-    )
-    layer.color_by = 'confidence'
+    layer = Tracks(data, properties=initial_properties)
+    layer.color_by = color_by
     controls = QtTracksControls(layer)
     qtbot.addWidget(controls)
 
     # Change the properties value by removing the time column.
-    layer.properties = {'confidence': initial_properties['confidence']}
+    layer.properties = {
+        'track_id': initial_properties['track_id'],
+        'confidence': initial_properties['confidence'],
+    }
 
-    assert layer.color_by == 'confidence'
+    assert layer.color_by == color_by

--- a/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
@@ -38,3 +38,37 @@ def test_tracks_controls_color_by(qtbot):
     qtctrl.color_by_combobox.setCurrentIndex(speed_index)
     assert layer.color_by == qt_update_color_by
     assert qtctrl.color_by_combobox.currentText() == qt_update_color_by
+
+
+def test_color_by_same_after_properties_change(qtbot):
+    """See https://github.com/napari/napari/issues/5330"""
+    data = np.array(
+        [
+            [1, 0, 236, 0],
+            [1, 1, 236, 100],
+            [1, 2, 236, 200],
+            [2, 0, 436, 0],
+            [2, 1, 436, 100],
+            [2, 2, 436, 200],
+            [3, 0, 636, 0],
+            [3, 1, 636, 100],
+            [3, 2, 636, 200],
+        ]
+    )
+    np.random.seed(0)
+    initial_properties = {
+        'time': data[:, 1],
+        'confidence': np.random.rand(data.shape[0]),
+    }
+    layer = Tracks(
+        data,
+        properties=initial_properties,
+    )
+    layer.color_by = 'confidence'
+    controls = QtTracksControls(layer)
+    qtbot.addWidget(controls)
+
+    # Change the properties value by removing the time column.
+    layer.properties = {'confidence': initial_properties['confidence']}
+
+    assert layer.color_by == 'confidence'

--- a/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
@@ -40,7 +40,13 @@ def test_tracks_controls_color_by(qtbot):
     assert qtctrl.color_by_combobox.currentText() == qt_update_color_by
 
 
-@pytest.mark.parametrize('color_by', ('track_id', 'confidence'))
+@pytest.mark.parametrize(
+    'color_by',
+    (
+        'track_id',
+        pytest.param('confidence', marks=pytest.mark.xfail),
+    ),
+)
 def test_color_by_same_after_properties_change(color_by, qtbot):
     """See https://github.com/napari/napari/issues/5330"""
     data = np.array(

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -199,7 +199,8 @@ def test_tracks_length_change():
     assert layer._max_length == track_length
 
 
-def test_color_by_same_after_properties_change():
+@pytest.mark.parametrize('color_by', ('track_id', 'confidence'))
+def test_color_by_same_after_properties_change(color_by):
     """See https://github.com/napari/napari/issues/5330"""
     data = np.array(
         [
@@ -214,15 +215,18 @@ def test_color_by_same_after_properties_change():
             [3, 2, 636, 200],
         ]
     )
-    np.random.seed(0)
     initial_properties = {
+        'track_id': data[:, 0],
         'time': data[:, 1],
-        'confidence': np.random.rand(data.shape[0]),
+        'confidence': np.ones(data.shape[0]),
     }
     layer = Tracks(data, properties=initial_properties)
-    layer.color_by = 'confidence'
+    layer.color_by = color_by
 
     # Change the properties value by removing the time column.
-    layer.properties = {'confidence': initial_properties['confidence']}
+    layer.properties = {
+        'track_id': initial_properties['track_id'],
+        'confidence': initial_properties['confidence'],
+    }
 
-    assert layer.color_by == 'confidence'
+    assert layer.color_by == color_by

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -197,3 +197,32 @@ def test_tracks_length_change():
     layer.head_length = track_length
     assert layer.head_length == track_length
     assert layer._max_length == track_length
+
+
+def test_color_by_same_after_properties_change():
+    """See https://github.com/napari/napari/issues/5330"""
+    data = np.array(
+        [
+            [1, 0, 236, 0],
+            [1, 1, 236, 100],
+            [1, 2, 236, 200],
+            [2, 0, 436, 0],
+            [2, 1, 436, 100],
+            [2, 2, 436, 200],
+            [3, 0, 636, 0],
+            [3, 1, 636, 100],
+            [3, 2, 636, 200],
+        ]
+    )
+    np.random.seed(0)
+    initial_properties = {
+        'time': data[:, 1],
+        'confidence': np.random.rand(data.shape[0]),
+    }
+    layer = Tracks(data, properties=initial_properties)
+    layer.color_by = 'confidence'
+
+    # Change the properties value by removing the time column.
+    layer.properties = {'confidence': initial_properties['confidence']}
+
+    assert layer.color_by == 'confidence'


### PR DESCRIPTION
# Description
This PR adds some test cases to cover the example described in https://github.com/napari/napari/issues/5330

I changed the example a little to make the data a little smaller (so the tests run fast) and also parametrized the tests of two possible valid `color_by` values. Note that `track_id` should always be a valid `color_by` value.

Initially, I just added a test for the `Tracks` layer type (in `napari/layers/tracks/_tests/test_tracks.py`), but those tests passed on `main`. So to mirror the example more accurately, I added a very similar test that integrates `QtTracksControls` with `Tracks` and it's only in that case that I see the error - this confirms the idea that the desired change is likely in `QtTracksControls`.

That fails on `main` when using a `color_by` value of `confidence`, but not `track_id`. It also fails with your current changes, so I marked it as an expected fail. I think that is due to the order of the property keys in the new properties - i.e. the first one will be used as the new `color_by` value.